### PR TITLE
use language list as default route in module

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -91,6 +91,11 @@ class Module extends \yii\base\Module {
     public $controllerNamespace = 'lajax\translatemanager\controllers';
 
     /**
+     * @inheritdoc
+     */
+    public $defaultRoute = 'language/list';
+
+    /**
      * @var string name of the used layout. If you want to use the site default layout set value null.
      */
     public $layout = 'language';


### PR DESCRIPTION
You can simply open `/translatemanager` to access the module, the list looks like the only possible default option, if you don't want to create a separate index view.