### PR TITLE
scan root fix

### DIFF
--- a/services/scanners/ScannerFile.php
+++ b/services/scanners/ScannerFile.php
@@ -173,13 +173,11 @@ abstract class ScannerFile extends \yii\console\controllers\MessageController {
     abstract protected function getLanguageItem($buffer);
 
     /**
-     * Returns the root directory of the project.
+     * Returns the root directory of the project scan.
      * @return string
      */
     private function _getRoot() {
-        $directories = explode(DIRECTORY_SEPARATOR, Yii::getAlias($this->module->root));
-        array_pop($directories);
-        return implode(DIRECTORY_SEPARATOR, $directories);
+        return Yii::getAlias($this->module->root);
     }
 
     /**


### PR DESCRIPTION
I actually wanted to fix windows by splitting at slashes and backslashes:
```php
$directories = preg_split("/(\\\\|\\/)/", Yii::getAlias($this->module->root));
```
But why even go to parent directory?