### PR TITLE
Add scanTimeLimit option

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -194,6 +194,11 @@ class Module extends \yii\base\Module {
      * @var string PHP Regular expression to match arrays containing language elements to translate.
      */
     public $patternArrayTranslator = '#\@translate[^\$]+(?P<translator>[\w\d\s_]+[^\(\[]+)#s';
+    
+    /**
+     * @var int The max_execution_time used when scanning, when set to null the default max_execution_time will not be modified.
+     */
+    public $scanTimeLimit = null;
 
     /**
      * examples:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ A more complex example including database table with multilingual support is bel
         'patterns' => ['*.js', '*.php'],// list of file extensions that contain language elements.
         'ignoredCategories' => ['yii'], // these categories won’t be included in the language database.
         'ignoredItems' => ['config'],   // these files will not be processed.
-        'scanTimeLimit' => null         // increase to prevent "Maximum execution time" errors, if null the default max_execution_time will be used
+        'scanTimeLimit' => null,         // increase to prevent "Maximum execution time" errors, if null the default max_execution_time will be used
         'tables' => [                   // Properties of individual tables
             [
                 'connection' => 'db',   // connection identifier

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ A more complex example including database table with multilingual support is bel
         'patterns' => ['*.js', '*.php'],// list of file extensions that contain language elements.
         'ignoredCategories' => ['yii'], // these categories won’t be included in the language database.
         'ignoredItems' => ['config'],   // these files will not be processed.
+        'scanTimeLimit' => null         // increase to prevent "Maximum execution time" errors, if null the default max_execution_time will be used
         'tables' => [                   // Properties of individual tables
             [
                 'connection' => 'db',   // connection identifier

--- a/services/Scanner.php
+++ b/services/Scanner.php
@@ -64,6 +64,13 @@ class Scanner {
      * @return integer The number of new language elements.
      */
     public function run() {
+        
+        $scanTimeLimit = Yii::$app->getModule('translatemanager')->scanTimeLimit;
+
+        if (!is_null($scanTimeLimit)) {
+            set_time_limit($scanTimeLimit);
+        }
+        
         $this->_initLanguageArrays();
 
         $languageSource = new LanguageSource;


### PR DESCRIPTION
Added an option to set the max_execution_time when scanning, this solves "Maximum execution time of 30 seconds exceeded" errors when scanning big projects.