### PR TITLE
cascade on update

### DIFF
--- a/migrations/m141002_030233_translate_manager.php
+++ b/migrations/m141002_030233_translate_manager.php
@@ -135,8 +135,8 @@ class m141002_030233_translate_manager extends Migration {
             'KEY `language` (language)'
         ], $tableOptions);
         
-        $this->addForeignKey('language_translate_ibfk_1', 'language_translate', ['language'], 'language', ['language_id'], 'CASCADE');
-        $this->addForeignKey('language_translate_ibfk_2', 'language_translate', ['id'], 'language_source', ['id'], 'CASCADE');
+        $this->addForeignKey('language_translate_ibfk_1', 'language_translate', ['language'], 'language', ['language_id'], 'CASCADE', 'CASCADE');
+        $this->addForeignKey('language_translate_ibfk_2', 'language_translate', ['id'], 'language_source', ['id'], 'CASCADE', 'CASCADE');
     }
 
     public function down() {


### PR DESCRIPTION
I think an update on the language and source id should cascade, not having this causes an error when updating a language:
```
SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails
```