### PR TITLE
Added option to search for not yet translated items

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -224,6 +224,11 @@ class Module extends \yii\base\Module {
      * @var string The database table storing the languages.
      */
     public $languageTable = '{{%language}}';
+		
+    /**
+     * @var string The search string to find empty translations.
+     */
+    public $searchEmptyCommand = '!';
 
     /**
      * @inheritdoc

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ A more complex example including database table with multilingual support is bel
         'ignoredCategories' => ['yii'], // these categories won’t be included in the language database.
         'ignoredItems' => ['config'],   // these files will not be processed.
         'scanTimeLimit' => null,        // increase to prevent "Maximum execution time" errors, if null the default max_execution_time will be used
+        'searchEmptyCommand' => '!'     // the search string to enter in the 'Translation' search field to find not yet translated items
         'tables' => [                   // Properties of individual tables
             [
                 'connection' => 'db',   // connection identifier

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ A more complex example including database table with multilingual support is bel
         'ignoredCategories' => ['yii'], // these categories won’t be included in the language database.
         'ignoredItems' => ['config'],   // these files will not be processed.
         'scanTimeLimit' => null,        // increase to prevent "Maximum execution time" errors, if null the default max_execution_time will be used
-        'searchEmptyCommand' => '!'     // the search string to enter in the 'Translation' search field to find not yet translated items
+        'searchEmptyCommand' => '!'     // the search string to enter in the 'Translation' search field to find not yet translated items, set to null to disable this feature
         'tables' => [                   // Properties of individual tables
             [
                 'connection' => 'db',   // connection identifier

--- a/models/searches/LanguageSourceSearch.php
+++ b/models/searches/LanguageSourceSearch.php
@@ -11,6 +11,7 @@ use Yii;
 use yii\base\Model;
 use yii\data\ActiveDataProvider;
 use lajax\translatemanager\models\LanguageSource;
+use lajax\translatemanager\Module;
 
 /**
  * LanguageSourceSearch represents the model behind the search form about `common\models\LanguageSource`.
@@ -83,7 +84,11 @@ class LanguageSourceSearch extends LanguageSource
 
         $query->joinWith(['languageTranslateByLanguage' => function ($query) {
             if ($this->translation) {
-                $query->andWhere(['like', 'translation', $this->translation]);
+                if ($this->translation == Module::getInstance()->searchEmptyCommand){
+                    $query->andWhere(['or', ['translation'=>null], ['translation'=>'']]);
+                }else{
+                    $query->andWhere(['like', 'translation', $this->translation]);
+                }
             }
         }]);
 

--- a/models/searches/LanguageSourceSearch.php
+++ b/models/searches/LanguageSourceSearch.php
@@ -84,7 +84,8 @@ class LanguageSourceSearch extends LanguageSource
 
         $query->joinWith(['languageTranslateByLanguage' => function ($query) {
             if ($this->translation) {
-                if ($this->translation == Module::getInstance()->searchEmptyCommand){
+								$searchEmptyCommand = Module::getInstance()->searchEmptyCommand;
+                if ($searchEmptyCommand && $this->translation == $searchEmptyCommand){
                     $query->andWhere(['or', ['translation'=>null], ['translation'=>'']]);
                 }else{
                     $query->andWhere(['like', 'translation', $this->translation]);


### PR DESCRIPTION
Added option to search for not yet translated items on the translation page.
When you search for `!` (configurable via the settings) only the rows that are not yet translated are displayed.

I have set the default value for the `searchEmptyCommand` to `!`, but for backwards compatibility you can also change this to `null`. In that case this feature would be disabled.