### PR TITLE
Using floor instead of round for complete percentage

### DIFF
--- a/models/Language.php
+++ b/models/Language.php
@@ -151,7 +151,7 @@ class Language extends \yii\db\ActiveRecord {
                     ->all();
 
             foreach ($languageTranslates as $languageTranslate) {
-                $statistics[$languageTranslate->language] = round($languageTranslate->cnt / $count, 2) * 100;
+                $statistics[$languageTranslate->language] = floor(($languageTranslate->cnt / $count) * 100);
             }
         }
 


### PR DESCRIPTION
Using floor instead of round in order to indicate that there are not yet translated items.