### PR TITLE
In DialogAction load the correct translation.

### DIFF
--- a/controllers/actions/DialogAction.php
+++ b/controllers/actions/DialogAction.php
@@ -4,6 +4,7 @@ namespace lajax\translatemanager\controllers\actions;
 
 use Yii;
 use lajax\translatemanager\models\LanguageSource;
+use lajax\translatemanager\models\LanguageTranslate;
 
 /**
  * Class for creating front end translation dialoge box
@@ -16,27 +17,43 @@ class DialogAction extends \yii\base\Action {
      * Creating dialogue box.
      * @return View
      */
-    public function run() {
-
+    public function run() 
+    {
         $languageSource = LanguageSource::findOne([
-                    'category' => Yii::$app->request->post('category', ''),
-                    'MD5(message)' => Yii::$app->request->post('hash', '')
+            'category' => Yii::$app->request->post('category', ''),
+            'MD5(message)' => Yii::$app->request->post('hash', '')
         ]);
 
         if (!$languageSource) {
             return '<div id="translate-manager-error">' . Yii::t('language', 'Text not found in database! Please run project scan before translating!') . '</div>';
         }
 
-        $languageTranslate = $languageSource->getLanguageTranslateByLanguage(Yii::$app->request->post('language_id', ''))->one() ? :
-                new \lajax\translatemanager\models\LanguageTranslate([
-            'id' => $languageSource->id,
-            'language' => Yii::$app->request->post('language_id', ''),
-        ]);
-
         return $this->controller->renderPartial('dialog', [
-                    'languageSource' => $languageSource,
-                    'languageTranslate' => $languageTranslate,
+            'languageSource' => $languageSource,
+            'languageTranslate' => $this->_getTranslation($languageSource),
         ]);
+    }
+    
+    /**
+     * @param LanguageSource $languageSource
+     * @return LanguageTranslate
+     */
+    private function _getTranslation($languageSource) 
+    {
+        $languageId = Yii::$app->request->post('language_id', '');
+        $languageTranslate = $languageSource
+            ->getLanguageTranslates()
+            ->andWhere(['language' => $languageId])
+            ->one();
+        
+        if (!$languageTranslate) {
+            $languageTranslate = new LanguageTranslate([
+                'id' => $languageSource->id,
+                'language' => $languageId
+            ]);
+        }
+        
+        return $languageTranslate;
     }
 
 }


### PR DESCRIPTION
Fixes #56. 

I decided to load the translation in the action, because `LanguageTranslate::getLanguageTranslateByIdAndLanguageId()` and `LanguageSource::getLanguageTranslateByLanguage()` is deprecated.