### PR TITLE
fix: PHP7 incompatibility in Database Scanner.

### DIFF
--- a/services/scanners/ScannerDatabase.php
+++ b/services/scanners/ScannerDatabase.php
@@ -87,7 +87,7 @@ class ScannerDatabase {
         $query = new \yii\db\Query();
         $data = $query->select($tables['columns'])
                 ->from($tables['table'])
-                ->createCommand(Yii::$app->$tables['connection'])
+                ->createCommand(Yii::$app->{$tables['connection']})
                 ->queryAll();
         $category = $this->_getCategory($tables);
         foreach ($data as $columns) {


### PR DESCRIPTION
With PHP7 there is an 'Array to string conversion' error in the Database Scanner. `$foo->$bar['baz']` is interpreted differently in PHP5 and PHP7 (`$foo->{$bar['baz']}` -> `($foo->$bar)['baz']`). 

This PR fixes this.