### PR TITLE
Fixed multiple translators detection in scanners.

### DIFF
--- a/services/scanners/ScannerFile.php
+++ b/services/scanners/ScannerFile.php
@@ -105,6 +105,21 @@ abstract class ScannerFile extends \yii\console\controllers\MessageController {
 
         parent::init();
     }
+    
+    /**
+     * Determines whether the file has any of the translators.
+     * 
+     * @param string[] $translators Array of translator patterns to search (for example: `['::t']`).
+     * @param string $file Path of the file.
+     * @return bool
+     */
+    protected function containsTranslator($translators, $file)
+    {
+        return preg_match(
+            '#(' . implode('\s*\()|(', array_map('preg_quote', $translators)) . '\s*\()#i',
+            file_get_contents($file)
+        ) > 0;
+    }
 
     /**
      * Extracts messages from a file

--- a/services/scanners/ScannerJavaScriptFunction.php
+++ b/services/scanners/ScannerJavaScriptFunction.php
@@ -36,7 +36,7 @@ class ScannerJavaScriptFunction extends ScannerFile {
     public function run($route, $params = array()) {
         $this->scanner->stdout('Detect JavaScriptFunction - BEGIN', Console::FG_YELLOW);
         foreach (self::$files[static::EXTENSION] as $file) {
-            if (preg_match('#' . preg_quote(implode('\s*\(|', $this->module->jsTranslators)) . '\s*\(#i', file_get_contents($file)) != false) {
+            if ($this->containsTranslator($this->module->jsTranslators, $file)) {
                 $this->extractMessages($file, [
                     'translator' => (array) $this->module->jsTranslators,
                     'begin' => '(',

--- a/services/scanners/ScannerPhpFunction.php
+++ b/services/scanners/ScannerPhpFunction.php
@@ -36,7 +36,7 @@ class ScannerPhpFunction extends ScannerFile {
     public function run($route, $params = array()) {
         $this->scanner->stdout('Detect PhpFunction - BEGIN', Console::FG_CYAN);
         foreach (self::$files[static::EXTENSION] as $file) {
-            if (preg_match('#' . preg_quote(implode('\s*\(|', $this->module->phpTranslators)) . '\s*\(#i', file_get_contents($file)) != false) {
+            if ($this->containsTranslator($this->module->phpTranslators, $file)) {
                 $this->extractMessages($file, [
                     'translator' => (array) $this->module->phpTranslators,
                     'begin' => '(',


### PR DESCRIPTION
When multiple JS or PHP translators are defined in config, the detection is not working (the regex pattern used for searching is incorrect). 

This PR fixes this, so multiple translators can be detected.