### PR TITLE
Added option to specify whether scan the parent directory of the root, or the root directory itself.

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -145,6 +145,21 @@ class Module extends \yii\base\Module {
      * @var string the root directory of the scanning.
      */
     public $root = '@app';
+    
+    /**
+     * @var bool Whether scan the defined `root` parent directory, or the folder itself.
+     * 
+     * <b>IMPORTANT</b>: Changing this from `true` to `false` could cause loss of translated items, as
+     * optimize action removes the missing items.
+     * 
+     * If the configured root is `@app`:
+     *  - `true` means for advanced apps, that the scan runs on the parent directory, which is the root for the entire project.
+     *     This is the desired behavior.
+     *  - `true` means for basic apps, that the scan runs also on the parent directory, which is outside of the project folder
+     *     (as `@app` is equals to the project root). This is not desired behavior, it is preferred to change this option
+     *     to `false`.
+     */
+    public $scanRootParentDirectory = true;
 
     /**
      * @var string writeable directory used for keeping the generated javascript files.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ A more complex example including database table with multilingual support is bel
     'translatemanager' => [
         'class' => 'lajax\translatemanager\Module',
         'root' => '@app',               // The root directory of the project scan.
+        'scanRootParentDirectory' => true, // Whether scan the defined `root` parent directory, or the folder itself.
+                                           // IMPORTANT: for detailed instructions read the chapter about root configuration.
         'layout' => 'language',         // Name of the used layout. If using own layout use 'null'.
         'allowedIPs' => ['127.0.0.1'],  // IP addresses from which the translation interface is accessible.
         'roles' => ['@'],               // For setting access levels to the translating interface.
@@ -118,7 +120,25 @@ A more complex example including database table with multilingual support is bel
 ],
 ```
 
-IMPORTANT: If you want to modify the value of roles (in other words to start using user roles) you need to enable authManager in the common config.
+#### Configuring the scan root
+
+The file scanner will scan the configured folders for translatable elements. The following two options
+determine the scan root directory: `root`, and `scanRootParentDirectory`. These options are defaults to
+values that works with the Yii 2 advanced project template. If you are using basic template, you have to modify 
+these settings.
+
+The `root` options tells which is the root folder for project scan. However if `scanRootParentDirectory` is set to `true`
+(which is the default value), the scan will run on the parent directory. This is desired behavior on advanced template,
+because the `@app` is the root for the current app, which is a subfolder inside the project (so the entire root of the
+project is the parent directory of `@app`).
+
+For basic template the `@app` is also the root for the entire project. Because of this with the default value 
+of `scanRootParentDirectory`, the scan runs outside the project folder. This is not desired behavior, and 
+changing the value to `false` solves this.
+
+**IMPORTANT: Changing the `scanRootParentDirectory` from `true` to `false` could cause loss of translated items, 
+as optimize action removes the missing items.** Changing the root folder can cause also loss, so be sure to 
+double check your configuration!
 
 Using of [authManager](http://www.yiiframework.com/doc-2.0/guide-security-authorization.html).
 

--- a/services/scanners/ScannerFile.php
+++ b/services/scanners/ScannerFile.php
@@ -94,12 +94,15 @@ abstract class ScannerFile extends \yii\console\controllers\MessageController {
     /**
      * @inheritdoc Initialise the $files static array.
      */
-    public function init() {
-
+    public function init() 
+    {
         if (empty(self::$files[static::EXTENSION]) && in_array(static::EXTENSION, $this->module->patterns)) {
-            self::$files[static::EXTENSION] = FileHelper::findFiles(realpath($this->_getRoot()), [
-                        'except' => $this->module->ignoredItems,
-                        'only' => [static::EXTENSION],
+            $root = realpath($this->_getRoot());
+            Yii::trace("Scanning " . static::EXTENSION . " files for language elements in: $root", 'translatemanager');
+            
+            self::$files[static::EXTENSION] = FileHelper::findFiles($root, [
+                'except' => $this->module->ignoredItems,
+                'only' => [static::EXTENSION],
             ]);
         }
 
@@ -215,8 +218,14 @@ abstract class ScannerFile extends \yii\console\controllers\MessageController {
      * Returns the root directory of the project scan.
      * @return string
      */
-    private function _getRoot() {
-        return dirname(Yii::getAlias($this->module->root));
+    private function _getRoot()
+    {
+        $root = Yii::getAlias($this->module->root);
+        if ($this->module->scanRootParentDirectory) {
+            $root = dirname($root);
+        }
+        
+        return $root;
     }
 
     /**


### PR DESCRIPTION
I tried to create a fix for the infamous parent directory scanning (mentioned in #12 first).

I added an option called `scanRootParentDirectory` to the module. With this, it is possible to specify scanning the root directory instead of the parent of the root directory. The default behaviour hasn't changed, this ensures backward compatibility.

I described this in the readme, I hope this make things clear for anyone. 

I also added a trace entry to make easier debugging the scanned directories.