### PR TITLE
added bundle that supports all active languages

### DIFF
--- a/assets/javascripts/lajax.js
+++ b/assets/javascripts/lajax.js
@@ -27,8 +27,12 @@ var lajax = (function () {
          * @returns {string}
          */
         t: function (message, $params) {
-            if (typeof (languageItems) !== 'undefined' && typeof (languageItems.getLanguageItems) === 'function') {
-                var $messages = languageItems.getLanguageItems();
+            if (
+                    typeof (languageItems) !== 'undefined' &&
+                    typeof (language) !== 'undefined' &&
+                    typeof (languageItems[language]) !== 'undefined' &&
+                    typeof (languageItems[language].getLanguageItems) === 'function') {
+                var $messages = languageItems[language].getLanguageItems();
                 if (typeof ($messages) !== 'undefined') {
                     var hash = md5(message);
                     if (typeof ($messages[hash]) !== 'undefined') {

--- a/bundles/AllLanguageItemPluginAsset.php
+++ b/bundles/AllLanguageItemPluginAsset.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace lajax\translatemanager\bundles;
+
+use yii\web\AssetBundle;
+
+/**
+ * AllLanguageItem Plugin asset bundle
+ * 
+ * @author Semenihin Maksim <semenihin.maksim@gmail.com>
+ * @since 1.0
+ *
+ * will include all active languages
+ */
+class AllLanguageItemPluginAsset extends LanguageItemPluginAsset {
+
+    public function init() {
+
+        parent::init();
+        $this->js = [];
+        $this->sourcePath = \Yii::$app->getModule('translatemanager')->getLanguageItemsDirPath();
+
+        $langs = \lajax\translatemanager\models\Language::findAll(['status'=>  \lajax\translatemanager\models\Language::STATUS_ACTIVE]);
+
+        foreach ($langs as $key => $lang){
+            if (file_exists(\Yii::getAlias($this->sourcePath . $lang->language_id . '.js'))) {
+                $this->js[] = $lang->language_id . '.js';
+            }
+        }
+
+    }
+
+}

--- a/bundles/FullTranslationPluginAsset.php
+++ b/bundles/FullTranslationPluginAsset.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace lajax\translatemanager\bundles;
+
+use yii\web\AssetBundle;
+
+/**
+ * Translation Plugin asset bundle
+ * 
+ * @author Semenihin Maksim <semenihin.maksim@gmail.com>
+ *
+ * @since 1.0
+ * will include all active languages
+ */
+class FullTranslationPluginAsset extends TranslationPluginAsset {
+
+    /**
+     * @inheritdoc
+     */
+    public $depends = [
+        'lajax\translatemanager\bundles\AllLanguageItemPluginAsset',
+    ];
+
+}


### PR DESCRIPTION
> Added bundle that supports all active languages


His can be handy if  site uses js compressor and one js file change only on deploy.
This mean that  all js langs files should be available any time.

- Added js var `language` with project lang.
- Added the ability to have all languages in js `languageItems` var.
- Added bundle that contains all active langs can be used for prod js compression.