### PR TITLE
Add optional Google translation of the source

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -283,6 +283,11 @@ class Module extends \yii\base\Module {
     public $scanners = [];
 
     /**
+     * @var string google API Key for using with google translate service (v2). Default is false - google translate will not be available.
+     */
+    public $googleApiKey = false;
+
+    /**
      * @inheritdoc
      */
     public function beforeAction($action) {

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ A more complex example including database table with multilingual support is bel
             '\lajax\translatemanager\services\scanners\ScannerJavaScriptFunction',
             '\lajax\translatemanager\services\scanners\ScannerDatabase',
         ],
+        'googleApiKey' => 'your_google_API_Key', // if set - google translation will be inserted into translation field when you click on the source field.  
     ],
 ],
 ```

--- a/README.md
+++ b/README.md
@@ -495,6 +495,29 @@ Use it with the Yii CLI
 ./yii translate/optimize
 ```
 
+###Using google translate api
+
+Google translate api is a paid service. At the moment of writing the price is $20 USD per 1 million characters trsanslated.
+
+In order to activate the feature you need to have Google account, generate google Api Key, and enable this feature
+by adding 'googleApiKey' to 'translatemanager' module configuration: 
+
+```php
+
+'modules' => [
+
+    'translatemanager' => [
+    
+        // ...
+        
+        'googleApiKey' => `Your_Google_API_Key',
+     ],
+],
+```
+Once feature is enabled it will insert google translation of the source into the empty translation field 
+(instead of original text) when you click on source field.
+
+
 Known issues
 -----------
 

--- a/assets/javascripts/helpers.js
+++ b/assets/javascripts/helpers.js
@@ -111,6 +111,33 @@ var helpers = (function () {
          */
         showErrorMessage: function (message, id) {
             $(id).next().html(_createMessage(message, 'alert-danger'));
+        },
+        /**
+         * Show error message.
+         * @param {string} text to translate
+         * @param {string} lang language code
+         * @param {callback} callback
+         */
+        googleTranslate: function (text, lang, callback) {
+            var xmlHttp = new XMLHttpRequest();
+            xmlHttp.onreadystatechange = function() {
+                if (xmlHttp.readyState == 4) {
+                    if (xmlHttp.status == 200) {
+                        var data = JSON.parse(xmlHttp.responseText);
+                        callback(data.data.translations[0].translatedText);
+                    }
+                    else {
+                        alert('Google Translate API failed with the following response:\n\n' + xmlHttp.responseText);
+                    }
+                }
+            };
+
+            var url = 'https://www.googleapis.com/language/translate/v2?key='+x_googleApiKey;
+            url += '&source=en&target='+lang.substring(0,2);
+            url += '&q='+encodeURI(text);
+
+            xmlHttp.open("GET", url, true);
+            xmlHttp.send(null);
         }
     };
 })();

--- a/assets/javascripts/translate.js
+++ b/assets/javascripts/translate.js
@@ -28,11 +28,24 @@ var translate = (function () {
      * @param {object} $this
      */
     function _copySourceToTranslation($this) {
-        if ($.trim($this.closest('tr').find('.translation').val()).length === 0) {
-            $this.closest('tr').find('.translation').val($.trim($this.val()));
-        }
 
-        _translateLanguage($this.closest('tr').find('button'));
+        if(typeof x_googleApiKey == 'undefined') // default bahavior - copy original text to translation field
+        {
+            if ($.trim($this.closest('tr').find('.translation').val()).length === 0) {
+                $this.closest('tr').find('.translation').val($.trim($this.val()));
+            }
+
+            _translateLanguage($this.closest('tr').find('button'));
+        }
+        else  // google translation is enabled - translate and copy translation ...
+        {
+            if ($.trim($this.closest('tr').find('.translation').val()).length === 0) {
+                helpers.googleTranslate($.trim($this.val()), $('#language_id').val(), function(result) {
+                    $this.closest('tr').find('.translation').val(result);
+                    _translateLanguage($this.closest('tr').find('button'));
+                });
+            }
+        }
     }
 
     return {

--- a/views/layouts/language.php
+++ b/views/layouts/language.php
@@ -24,6 +24,11 @@ TranslateManagerAsset::register($this);
         <?= Html::csrfMetaTags() ?>
         <title><?= Html::encode($this->title) ?></title>
         <?php $this->head() ?>
+        <?php if(!empty(Yii::$app->getModule('translatemanager')->googleApiKey)) { ?>
+        <script type="text/javascript">
+            var x_googleApiKey = '<?= Yii::$app->getModule('translatemanager')->googleApiKey?>';
+        </script>
+        <?php } ?>
     </head>
     <body>
         <?php $this->beginBody() ?>


### PR DESCRIPTION
If new 'googleApiKey' is set in the Model configuration - it will insert google translation of the source text into empty translation field (instead of original text) when you click on the source message.
If 'googleApiKey' is not set - original behavior is preserved.
This is paid google service. $20 / million characters. You have to have google account and create your own api key to use it.