### PR TITLE
Add namespaced migration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,28 @@ to the require section of your `composer.json` file.
 
 ### Migration
 
-
 Run the following command in Terminal for database migration:
 
-Linux/Unix:
 ```
 yii migrate/up --migrationPath=@vendor/lajax/yii2-translate-manager/migrations
 ```
 
-Windows:
+Or use the [namespaced migration](http://www.yiiframework.com/doc-2.0/guide-db-migrations.html#namespaced-migrations) (requires at least Yii 2.0.10):
+
+```php
+// Add namespace to console config:
+'controllerMap' => [
+    'migrate' => [
+        'class' => 'yii\console\controllers\MigrateController',
+        'migrationNamespaces' => [
+            'lajax\translatemanager\migrations\namespaced',
+        ],
+    ],
+],
 ```
-yii.bat migrate/up --migrationPath=@vendor/lajax/yii2-translate-manager/migrations
+
+```
+yii migrate/up
 ```
 
 ### Config

--- a/migrations/namespaced/m141002_030233_translate_manager_ns.php
+++ b/migrations/namespaced/m141002_030233_translate_manager_ns.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace lajax\translatemanager\migrations\namespaced;
+
+require_once dirname(__DIR__) . '/m141002_030233_translate_manager.php';
+
+/**
+ * Migration to support namespaced migrations.
+ *
+ * This migration can be used instead of the one with global namespace.
+ *
+ * @see https://github.com/yiisoft/yii2/blob/2.0.10/framework/console/controllers/BaseMigrateController.php#L60
+ *
+ * @author moltam
+ */
+class m141002_030233_translate_manager_ns extends \m141002_030233_translate_manager
+{
+}


### PR DESCRIPTION
A new migration with namespace is added that extends the old one
(global migration). This way the users can choose between them,
and also revert the global migration after the upgrade.

Fixes #98