### PR TITLE
fixed url creation

### DIFF
--- a/views/language/translate.php
+++ b/views/language/translate.php
@@ -23,7 +23,7 @@ $this->params['breadcrumbs'][] = ['label' => Yii::t('language', 'Languages'), 'u
 $this->params['breadcrumbs'][] = $this->title;
 ?>
 
-<?= Html::hiddenInput('language_id', $language_id, ['id' => 'language_id', 'data-url' => Yii::$app->urlManager->createAbsoluteUrl('/translatemanager/language/save')]); ?>
+<?= Html::hiddenInput('language_id', $language_id, ['id' => 'language_id', 'data-url' => Yii::$app->urlManager->createUrl('/translatemanager/language/save')]); ?>
 <div id="translates" class="<?= $language_id ?>">
     <?php
     Pjax::begin([


### PR DESCRIPTION
The save action was triggered via an absolute URL, which can be problematic in some scenarios - and it should not be required to use an absolute URL here.