### PR TITLE
Restrict version constraints for Yii dependencies in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         }
     ],
     "require": {
-        "yiisoft/yii2": "*",
-        "yiisoft/yii2-jui": "*",
-        "yiisoft/yii2-bootstrap": "*"
+        "yiisoft/yii2": "~2.0.0",
+        "yiisoft/yii2-jui": "~2.0.0",
+        "yiisoft/yii2-bootstrap": "~2.0.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.1"


### PR DESCRIPTION
Since Yii 2.1 is in development, the dependencies need to be specified with more restrictive version constraints.