### PR TITLE
Fix invalid column name in findOne() condition

### DIFF
--- a/controllers/actions/DialogAction.php
+++ b/controllers/actions/DialogAction.php
@@ -22,10 +22,10 @@ class DialogAction extends \yii\base\Action
      */
     public function run()
     {
-        $languageSource = LanguageSource::findOne([
+        $languageSource = LanguageSource::find()->where([
             'category' => Yii::$app->request->post('category', ''),
             'MD5(message)' => Yii::$app->request->post('hash', ''),
-        ]);
+        ])->one();
 
         if (!$languageSource) {
             return '<div id="translate-manager-error">' . Yii::t('language', 'Text not found in database! Please run project scan before translating!') . '</div>';


### PR DESCRIPTION
For security reasons the ActiveRecord::findOne() checks the existence
of a column since Yii 2.0.15. Because of this, the 'md5(column)'
format is not accepted anymore, so the regular find() method
need to be used instead.

fixes #117