### PR TITLE
Fix for sizing on textarea boxes

### DIFF
--- a/assets/stylesheets/translate.css
+++ b/assets/stylesheets/translate.css
@@ -4,9 +4,15 @@
  */
 
 #translates textarea {
-    height:47px;
+    margin: 0 !important;
+    max-width: 1000px;
+    max-height: 1000px;
 }
 
 #translates.ar-AR textarea.translation {
     direction: rtl;
+}
+
+#translates td {
+    width: 400px;
 }

--- a/assets/stylesheets/translate.css
+++ b/assets/stylesheets/translate.css
@@ -5,8 +5,8 @@
 
 #translates textarea {
     margin: 0 !important;
-    max-width: 1000px;
-    max-height: 1000px;
+    max-width: 1000px !important;
+    max-height: 1000px !important;
 }
 
 #translates.ar-AR textarea.translation {


### PR DESCRIPTION
I was having issues with when trying to resize textboxes in the translate manager. A large margin would appear on the right, making it very hard to work with.
This was the solution I came up with. Unfortunately I couldn't get it to work without the ```!important``` tags as I couldn't find where the margins and widths were being applied from.
So a better fix might be possible.

Before:
![before](https://user-images.githubusercontent.com/14820555/68866449-59fca700-06ec-11ea-8c44-5df25a4fbc36.jpg)

After:
![after](https://user-images.githubusercontent.com/14820555/68866465-608b1e80-06ec-11ea-9612-d43afafb3a9a.jpg)
