### PR TITLE
Remove empty translates to have actual statistic

### DIFF
--- a/controllers/actions/SaveAction.php
+++ b/controllers/actions/SaveAction.php
@@ -27,12 +27,28 @@ class SaveAction extends \yii\base\Action
 
         $id = Yii::$app->request->post('id', 0);
         $languageId = Yii::$app->request->post('language_id', Yii::$app->language);
+        $translation = Yii::$app->request->post('translation', '');
 
-        $languageTranslate = LanguageTranslate::findOne(['id' => $id, 'language' => $languageId]) ?:
-            new LanguageTranslate(['id' => $id, 'language' => $languageId]);
+        $languageTranslate = LanguageTranslate::findOne(['id' => $id, 'language' => $languageId]);
 
-        $languageTranslate->translation = Yii::$app->request->post('translation', '');
-        if ($languageTranslate->validate() && $languageTranslate->save()) {
+        $regenerate = false;
+
+        if ('' == trim($translation)) {
+            if ($languageTranslate && $languageTranslate->delete()) {
+                $regenerate = true;
+            } else {
+                return [];
+            }
+        } else {
+            $languageTranslate = $languageTranslate ?:
+                new LanguageTranslate(['id' => $id, 'language' => $languageId]);
+            $languageTranslate->translation = $translation;
+            if ($languageTranslate->validate() && $languageTranslate->save()) {
+                $regenerate = true;
+            }
+        }
+
+        if ($regenerate) {
             $generator = new Generator($this->controller->module, $languageId);
 
             $generator->run();

--- a/services/Optimizer.php
+++ b/services/Optimizer.php
@@ -4,6 +4,7 @@ namespace lajax\translatemanager\services;
 
 use yii\helpers\Console;
 use lajax\translatemanager\models\LanguageSource;
+use lajax\translatemanager\models\LanguageTranslate;
 
 /**
  * Optimizer class for optimizing database tables
@@ -52,6 +53,9 @@ class Optimizer
         $this->_initLanguageElements($languageSourceIds);
 
         LanguageSource::deleteAll(['id' => $languageSourceIds]);
+
+        $numberOfDeletetRows = LanguageTranslate::deleteAll(['translation' => '']);
+        $this->_scanner->stdout('Removed empty elements - ' . $numberOfDeletetRows, Console::FG_RED);
 
         $this->_scanner->stdout('Deleted language elements - END', Console::FG_RED);
 


### PR DESCRIPTION
Remove empty translates to have a correct statistic on the page "translatemanager/language/list".